### PR TITLE
Allow catching connection errors in `catch` node.

### DIFF
--- a/nodes/xbox-controller.js
+++ b/nodes/xbox-controller.js
@@ -65,7 +65,7 @@ module.exports = function (RED) {
             node.status({})
           });
         }, function (error) {
-          node.error(error, '');
+          node.error("Failed to connect", error);
           node.status({})
         });
       } else if (msg.payload == 'on') {
@@ -95,7 +95,7 @@ module.exports = function (RED) {
             node.status({})
           });
         }, function (error) {
-          node.error(error, '');
+          node.error("Failed to connect", error);
           node.status({})
         });
       } else if (msg.payload == "getActiveApp" || msg.payload == "getBoxInfo") {
@@ -106,7 +106,7 @@ module.exports = function (RED) {
           node.send(msg);
           node.status({})
         }, function (error) {
-          node.error(error, '');
+          node.error("Failed to connect", error);
           node.status({})
         });
       } else {

--- a/nodes/xbox-controller.js
+++ b/nodes/xbox-controller.js
@@ -61,16 +61,16 @@ module.exports = function (RED) {
             node.send(msg);
             node.status({})
           }, function (error) {
-            node.error(error);
+            node.error(error, msg);
             node.status({})
           });
         }, function (error) {
-          node.error("Failed to connect", error);
+          node.error(error, msg);
           node.status({})
         });
       } else if (msg.payload == 'on') {
         if (ip == null) {
-          node.error("Can't use Broadcast for turning on");
+          node.error("Can't use Broadcast for turning on", msg);
           node.status({})
           return
         }
@@ -82,7 +82,7 @@ module.exports = function (RED) {
           node.send(msg);
           node.status({})
         }, function (error) {
-          node.error(error.error);
+          node.error(error.error, msg);
           node.status({})
         });
       } else if (msg.payload == 'off') {
@@ -91,11 +91,11 @@ module.exports = function (RED) {
             node.send(msg);
             node.status({})
           }, function (error) {
-            node.error(error);
+            node.error(error, msg);
             node.status({})
           });
         }, function (error) {
-          node.error("Failed to connect", error);
+          node.error(error, msg);
           node.status({})
         });
       } else if (msg.payload == "getActiveApp" || msg.payload == "getBoxInfo") {
@@ -106,11 +106,11 @@ module.exports = function (RED) {
           node.send(msg);
           node.status({})
         }, function (error) {
-          node.error("Failed to connect", error);
+          node.error(error, msg);
           node.status({})
         });
       } else {
-        node.error("Unsupported input: " + msg.payload);
+        node.error("Unsupported input: " + msg.payload, msg);
         node.status({})
       };
     });

--- a/nodes/xbox-controller.js
+++ b/nodes/xbox-controller.js
@@ -65,7 +65,7 @@ module.exports = function (RED) {
             node.status({})
           });
         }, function (error) {
-          node.error(error);
+          node.error(error, '');
           node.status({})
         });
       } else if (msg.payload == 'on') {
@@ -95,7 +95,7 @@ module.exports = function (RED) {
             node.status({})
           });
         }, function (error) {
-          node.error(error);
+          node.error(error, '');
           node.status({})
         });
       } else if (msg.payload == "getActiveApp" || msg.payload == "getBoxInfo") {
@@ -106,7 +106,7 @@ module.exports = function (RED) {
           node.send(msg);
           node.status({})
         }, function (error) {
-          node.error(error);
+          node.error(error, '');
           node.status({})
         });
       } else {


### PR DESCRIPTION
According to https://discourse.nodered.org/t/node-error-not-caught-in-catch-node/1301/3, a second argument is needed for errors to be catchable.